### PR TITLE
Feature: add education to user schema

### DIFF
--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -29,6 +29,7 @@ model User {
   // Social Links, Experience, Badges - REVISIT OPTIONS BELOW
   socialLinks SocialLink[]
   experiences Experience[]
+  education   Education[]
 
   earnedSkillBadges          SkillLevelBadge[] // List of badges for skill progression
   earnedSpecializationBadges SpecializationBadge[] // List of badges for expertise areas
@@ -57,6 +58,14 @@ type Experience {
   company     String
   startDate   DateTime
   endDate     DateTime? // Optional end date if current
+  description String?
+}
+
+type Education {
+  degree      String
+  school      String
+  startDate   DateTime
+  endDate     DateTime?
   description String?
 }
 


### PR DESCRIPTION
This pull request updates the Prisma schema to add support for tracking user education history. The main changes are the introduction of a new `Education` type and associating it with the `User` model.

Schema enhancements for education tracking:

* Added a new `Education` type to the schema, including fields for `degree`, `school`, `startDate`, `endDate`, and an optional `description`.
* Updated the `User` model to include an `education` field, which is an array of `Education` objects, allowing users to have multiple education entries.