### PR TITLE
113 implement a public profile page for user

### DIFF
--- a/app/profile/[userId]/page.tsx
+++ b/app/profile/[userId]/page.tsx
@@ -1,0 +1,157 @@
+const mockUser = {
+  id: "1",
+  clerkId: "user_123",
+  email: "monyvann.men@example.com",
+  firstName: "Monyvann",
+  lastName: "Men",
+  bio: "I am a fourth-year undergraduate student pursuing a Bachelor of Science in Computer Science, possessing over three years of software development experience. Concurrently with my studies, I am employed as a teaching assistant for the university campus, where I apply my technical skills in a practical setting.",
+  intro: "ITM Senior at AUPP | CS Senior at PTSU",
+  address: "Lynn, Massachusetts, United States",
+  skills: [
+    "JavaScript",
+    "React",
+    "Node.js",
+    "Python",
+    "TypeScript",
+    "Vue.js",
+    "PHP",
+  ],
+  imageUrl:
+    "https://img.clerk.com/eyJ0eXBlIjoicHJveHkiLCJzcmMiOiJodHRwczovL2ltYWdlcy5jbGVyay5kZXYvb2F1dGhfZ29vZ2xlL2ltZ18zMlRsalpHRmZCNVYyck94RnFJa0FhYzR5TXQifQ",
+  role: "USER" as const,
+  occupied: false,
+  createdAt: new Date("2021-01-01"),
+  updatedAt: new Date("2024-09-13"),
+  socialLinks: [
+    { type: "LinkedIn", url: "https://linkedin.com/in/monyvann-men-6cb7a260" },
+  ],
+  experiences: [
+    {
+      id: "1",
+      title: "Web Developer",
+      company: "American University of Phnom Penh",
+      startDate: new Date("2024-02-01"),
+      endDate: new Date("2024-12-01"),
+      description:
+        "Developed a complete web application for ID Management and Request Engine. Utilized technologies such as Vue.js, JavaScript, and PHP to build and enhance web applications.",
+    },
+    {
+      id: "2",
+      title: "Frontend Developer",
+      company: "Ministry of Interior, Cambodia",
+      startDate: new Date("2024-01-01"),
+      endDate: new Date("2024-04-01"),
+      description:
+        "Developed up to 10 responsive web pages based on UX/UI designs using Vue.js and Laravel. Established robust frontend to backend connections, optimizing system functionality and user performance.",
+    },
+  ],
+  education: [
+    {
+      id: "1",
+      institution: "Paragon International University",
+      degree: "Bachelor of Science",
+      field: "Computer Science",
+      startDate: new Date("2021-09-01"),
+      endDate: new Date("2025-06-01"),
+      description:
+        "Pursuing Bachelor's degree with focus on software development and computer science fundamentals.",
+    },
+    {
+      id: "2",
+      institution: "American University of Phnom Penh",
+      degree: "Information Technology Management",
+      field: "Business Technology",
+      startDate: new Date("2020-09-01"),
+      endDate: new Date("2024-06-01"),
+      description:
+        "Completed ITM program with emphasis on technology management and business applications.",
+    },
+  ],
+  projects: [
+    {
+      id: "1",
+      title: "Student Management System",
+      description:
+        "A comprehensive web application for managing student records, course enrollment, and academic progress tracking. Built with modern web technologies and responsive design.",
+      category: "WEB_DEVELOPMENT",
+      scope: "INTERMEDIATE",
+      status: "COMPLETED",
+      startDate: new Date("2024-01-15"),
+      estimatedEndDate: new Date("2024-05-30"),
+      budget: 5000,
+      requiredSkills: [
+        "React",
+        "Node.js",
+        "MongoDB",
+        "Express.js",
+        "TypeScript",
+      ],
+    },
+    {
+      id: "2",
+      title: "E-Commerce Mobile App",
+      description:
+        "Cross-platform mobile application for online shopping with payment integration, user authentication, and real-time order tracking capabilities.",
+      category: "MOBILE_DEVELOPMENT",
+      scope: "ADVANCED",
+      status: "IN_PROGRESS",
+      startDate: new Date("2024-06-01"),
+      estimatedEndDate: new Date("2024-12-15"),
+      budget: 12000,
+      requiredSkills: [
+        "React Native",
+        "Firebase",
+        "Stripe API",
+        "Redux",
+        "JavaScript",
+      ],
+    },
+    {
+      id: "3",
+      title: "Data Analytics Dashboard",
+      description:
+        "Interactive dashboard for visualizing business metrics and KPIs with real-time data processing and customizable reporting features.",
+      category: "DATA_SCIENCE",
+      scope: "EXPERT",
+      status: "OPEN",
+      startDate: new Date("2024-10-01"),
+      estimatedEndDate: new Date("2025-03-30"),
+      budget: 8500,
+      requiredSkills: [
+        "Python",
+        "D3.js",
+        "PostgreSQL",
+        "Docker",
+        "Machine Learning",
+      ],
+    },
+  ],
+  earnedSkillBadges: ["INTERMEDIATE"],
+  earnedSpecializationBadges: ["WEB_DEVELOPER_PRO"],
+  earnedEngagementBadges: [],
+  totalHoursContributed: 1200,
+  projectsCompleted: 8,
+  industriesExperienced: ["Education", "Government", "Technology"],
+};
+
+import { ProfileContent } from "@/components/profile/ProfileContent";
+import { ProfileHeader } from "@/components/profile/ProfileHeader";
+import { ProfileSidebar } from "@/components/profile/ProfileSidebar";
+
+export default function UserProfile() {
+  return (
+    <div className="min-h-screen bg-muted/30">
+      <div className="max-w-7xl mx-auto">
+        <ProfileHeader user={mockUser} />
+        <div className="grid grid-cols-1 lg:grid-cols-4 gap-6 px-4 pb-8">
+          <div className="lg:col-span-3">
+            <ProfileContent user={mockUser} />
+          </div>
+          <div className="lg:col-span-1">
+            <ProfileSidebar />
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/components/profile/ProfileContent.tsx
+++ b/components/profile/ProfileContent.tsx
@@ -1,0 +1,271 @@
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+
+import {
+  Building2,
+  Calendar,
+  GraduationCap,
+  FolderOpen,
+  Clock,
+  DollarSign,
+} from "lucide-react";
+
+interface User {
+  bio: string;
+  experiences: Array<{
+    id: string;
+    title: string;
+    company: string;
+    startDate: Date;
+    endDate: Date | null;
+    description?: string;
+  }>;
+  education: Array<{
+    id: string;
+    institution: string;
+    degree: string;
+    field: string;
+    startDate: Date;
+    endDate: Date | null;
+    description?: string;
+  }>;
+  projects: Array<{
+    id: string;
+    title: string;
+    description: string;
+    category: string;
+    scope: string;
+    status: string;
+    startDate: Date;
+    estimatedEndDate: Date;
+    budget: number;
+    requiredSkills: string[];
+  }>;
+  totalHoursContributed: number;
+  projectsCompleted: number;
+}
+
+interface ProfileContentProps {
+  user: User;
+}
+
+export function ProfileContent({ user }: ProfileContentProps) {
+  const formatDate = (date: Date) => {
+    return date.toLocaleDateString("en-US", {
+      month: "short",
+      year: "numeric",
+    });
+  };
+
+  const calculateDuration = (start: Date, end: Date | null) => {
+    const endDate = end || new Date();
+    const months = Math.round(
+      (endDate.getTime() - start.getTime()) / (1000 * 60 * 60 * 24 * 30)
+    );
+    if (months < 12) return `${months} mos`;
+    const years = Math.floor(months / 12);
+    const remainingMonths = months % 12;
+    return remainingMonths > 0
+      ? `${years} yr ${remainingMonths} mos`
+      : `${years} yr`;
+  };
+
+  const formatStatus = (status: string) => {
+    return status
+      .replace(/_/g, " ")
+      .toLowerCase()
+      .replace(/\b\w/g, (l) => l.toUpperCase());
+  };
+
+  const formatBudget = (budget: number) => {
+    return new Intl.NumberFormat("en-US", {
+      style: "currency",
+      currency: "USD",
+      minimumFractionDigits: 0,
+      maximumFractionDigits: 0,
+    }).format(budget);
+  };
+
+  return (
+    <div className="space-y-6 pb-10">
+      {/* About Section */}
+      <Card>
+        <CardHeader className="flex flex-row items-center justify-between">
+          <CardTitle className="text-lg">About</CardTitle>
+        </CardHeader>
+        <CardContent>
+          <p className="text-sm leading-relaxed text-pretty">{user.bio}</p>
+        </CardContent>
+      </Card>
+
+      {/* Experience Section */}
+      <Card>
+        <CardHeader className="flex flex-row items-center justify-between">
+          <CardTitle className="text-lg">Experience</CardTitle>
+        </CardHeader>
+        <CardContent className="space-y-6">
+          {user.experiences.map((experience, index) => (
+            <div key={experience.id} className="flex gap-4">
+              <div className="w-12 h-12 bg-muted rounded-lg flex items-center justify-center flex-shrink-0">
+                <Building2 className="h-6 w-6 text-muted-foreground" />
+              </div>
+
+              <div className="flex-1 min-w-0">
+                <h3 className="font-semibold text-balance">
+                  {experience.title}
+                </h3>
+                <p className="text-muted-foreground">{experience.company}</p>
+                <div className="flex items-center gap-1 text-sm text-muted-foreground mt-1">
+                  <Calendar className="h-3 w-3" />
+                  <span>
+                    {formatDate(experience.startDate)} -{" "}
+                    {experience.endDate
+                      ? formatDate(experience.endDate)
+                      : "Present"}
+                  </span>
+                  <span>·</span>
+                  <span>
+                    {calculateDuration(
+                      experience.startDate,
+                      experience.endDate
+                    )}
+                  </span>
+                </div>
+                <p className="text-sm text-muted-foreground mt-2 leading-relaxed">
+                  {experience.description}
+                </p>
+                {index < user.experiences.length - 1 && (
+                  <hr className="mt-6 border-border" />
+                )}
+              </div>
+            </div>
+          ))}
+        </CardContent>
+      </Card>
+
+      {/* Education Section */}
+      <Card>
+        <CardHeader className="flex flex-row items-center justify-between">
+          <CardTitle className="text-lg">Education</CardTitle>
+        </CardHeader>
+        <CardContent className="space-y-6">
+          {user.education.map((edu, index) => (
+            <div key={edu.id} className="flex gap-4">
+              <div className="w-12 h-12 bg-muted rounded-lg flex items-center justify-center flex-shrink-0">
+                <GraduationCap className="h-6 w-6 text-muted-foreground" />
+              </div>
+
+              <div className="flex-1 min-w-0">
+                <h3 className="font-semibold text-balance">
+                  {edu.institution}
+                </h3>
+                <p className="text-muted-foreground">
+                  {edu.degree} in {edu.field}
+                </p>
+                <div className="flex items-center gap-1 text-sm text-muted-foreground mt-1">
+                  <Calendar className="h-3 w-3" />
+                  <span>
+                    {formatDate(edu.startDate)} -{" "}
+                    {edu.endDate ? formatDate(edu.endDate) : "Present"}
+                  </span>
+                  <span>·</span>
+                  <span>{calculateDuration(edu.startDate, edu.endDate)}</span>
+                </div>
+                {edu.description && (
+                  <p className="text-sm text-muted-foreground mt-2 leading-relaxed">
+                    {edu.description}
+                  </p>
+                )}
+                {index < user.education.length - 1 && (
+                  <hr className="mt-6 border-border" />
+                )}
+              </div>
+            </div>
+          ))}
+        </CardContent>
+      </Card>
+
+      {/* Projects Section */}
+      <Card>
+        <CardHeader className="flex flex-row items-center justify-between">
+          <CardTitle className="text-lg">Projects</CardTitle>
+        </CardHeader>
+        <CardContent className="space-y-6">
+          {user.projects.map((project, index) => (
+            <div key={project.id} className="flex gap-4">
+              <div className="w-12 h-12 bg-muted rounded-lg flex items-center justify-center flex-shrink-0">
+                <FolderOpen className="h-6 w-6 text-muted-foreground" />
+              </div>
+
+              <div className="flex-1 min-w-0">
+                <div className="flex items-start justify-between gap-4">
+                  <div className="flex-1">
+                    <h3 className="font-semibold text-balance">
+                      {project.title}
+                    </h3>
+                    <div className="flex items-center gap-2 mt-1">
+                      <span className="text-sm text-muted-foreground">
+                        {formatStatus(project.category)}
+                      </span>
+                      <span className="text-muted-foreground">·</span>
+                      <span className="text-sm text-muted-foreground">
+                        {formatStatus(project.scope)}
+                      </span>
+                    </div>
+                  </div>
+                  <div className="flex items-center gap-4 text-sm text-muted-foreground">
+                    <div className="flex items-center gap-1">
+                      <DollarSign className="h-3 w-3" />
+                      <span>{formatBudget(project.budget)}</span>
+                    </div>
+                    <div
+                      className={`px-2 py-1 rounded-full text-xs font-medium ${
+                        project.status === "COMPLETED"
+                          ? "bg-green-100 text-green-800"
+                          : project.status === "IN_PROGRESS"
+                          ? "bg-blue-100 text-blue-800"
+                          : project.status === "OPEN"
+                          ? "bg-yellow-100 text-yellow-800"
+                          : "bg-gray-100 text-gray-800"
+                      }`}
+                    >
+                      {formatStatus(project.status)}
+                    </div>
+                  </div>
+                </div>
+
+                <div className="flex items-center gap-1 text-sm text-muted-foreground mt-2">
+                  <Clock className="h-3 w-3" />
+                  <span>
+                    {formatDate(project.startDate)} -{" "}
+                    {formatDate(project.estimatedEndDate)}
+                  </span>
+                </div>
+
+                <p className="text-sm text-muted-foreground mt-2 leading-relaxed">
+                  {project.description}
+                </p>
+
+                {project.requiredSkills.length > 0 && (
+                  <div className="flex flex-wrap gap-2 mt-3">
+                    {project.requiredSkills.map((skill, skillIndex) => (
+                      <span
+                        key={skillIndex}
+                        className="px-2 py-1 bg-muted rounded-md text-xs font-medium text-muted-foreground"
+                      >
+                        {skill}
+                      </span>
+                    ))}
+                  </div>
+                )}
+
+                {index < user.projects.length - 1 && (
+                  <hr className="mt-6 border-border" />
+                )}
+              </div>
+            </div>
+          ))}
+        </CardContent>
+      </Card>
+    </div>
+  );
+}

--- a/components/profile/ProfileHeader.tsx
+++ b/components/profile/ProfileHeader.tsx
@@ -1,0 +1,150 @@
+import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
+import { Badge } from "@/components/ui/badge";
+import { MapPin, Award, Clock, Briefcase } from "lucide-react";
+import Image from "next/image";
+
+interface User {
+  firstName: string;
+  lastName: string;
+  intro: string;
+  address: string;
+  skills: string[];
+  imageUrl: string;
+  experiences: Array<{
+    title: string;
+    company: string;
+  }>;
+  earnedSkillBadges: string[];
+  earnedSpecializationBadges: string[];
+  earnedEngagementBadges: string[];
+  totalHoursContributed: number;
+  projectsCompleted: number;
+  industriesExperienced: string[];
+}
+
+interface ProfileHeaderProps {
+  user: User;
+}
+
+export function ProfileHeader({ user }: ProfileHeaderProps) {
+  return (
+    <div className="mx-4 mt-4 mb-6 overflow-hidden">
+      {/* Header Background */}
+      <Image
+        src="/bg.jpeg"
+        alt="bg"
+        width={1920}
+        height={1080}
+        className="h-[400px]"
+      />
+
+      <div className="relative px-6 pb-6">
+        {/* Profile Picture */}
+        <div className="absolute -top-20 left-6">
+          <Avatar className="w-40 h-40 border-4 border-background">
+            <AvatarImage src={user.imageUrl} />
+            <AvatarFallback className="text-2xl bg-muted">
+              {user.firstName[0]}
+              {user.lastName[0]}
+            </AvatarFallback>
+          </Avatar>
+        </div>
+
+        {/* Profile Info */}
+        <div className="pt-24 flex justify-between items-start">
+          <div className="flex-1">
+            <div className="flex items-center gap-2 mb-2">
+              <h1 className="text-3xl font-bold text-balance capitalize">
+                {user.firstName} {user.lastName}
+              </h1>
+            </div>
+
+            <p className="text-xl text-muted-foreground mb-3 text-pretty">
+              {user.intro}
+            </p>
+
+            <div className="flex items-center gap-4 text-sm text-muted-foreground mb-4">
+              <div className="flex items-center gap-1">
+                <MapPin className="h-4 w-4" />
+                {user.address}
+              </div>
+            </div>
+
+            {/* Badges and Stats Section */}
+            <div className="space-y-3 mb-4">
+              {/* Skill Badges */}
+              {user.earnedSkillBadges.length > 0 && (
+                <div className="flex items-center gap-2">
+                  <Award className="h-4 w-4 text-amber-600" />
+                  <span className="text-sm font-medium">Skill Badges:</span>
+                  {user.earnedSkillBadges.map((badge) => (
+                    <Badge
+                      key={badge}
+                      variant="outline"
+                      className="text-xs bg-amber-50 text-amber-700 border-amber-200"
+                    >
+                      {badge}
+                    </Badge>
+                  ))}
+                </div>
+              )}
+
+              {/* Specialization Badges */}
+              {user.earnedSpecializationBadges.length > 0 && (
+                <div className="flex items-center gap-2">
+                  <Award className="h-4 w-4 text-emerald-600" />
+                  <span className="text-sm font-medium">Specializations:</span>
+                  {user.earnedSpecializationBadges.map((badge) => (
+                    <Badge
+                      key={badge}
+                      variant="outline"
+                      className="text-xs bg-emerald-50 text-emerald-700 border-emerald-200"
+                    >
+                      {badge.replace(/_/g, " ")}
+                    </Badge>
+                  ))}
+                </div>
+              )}
+
+              {/* Stats */}
+              <div className="flex items-center gap-6 text-sm">
+                <div className="flex items-center gap-1">
+                  <Clock className="h-4 w-4 text-blue-600" />
+                  <span className="font-medium">
+                    {user.totalHoursContributed.toLocaleString()}
+                  </span>
+                  <span className="text-muted-foreground">
+                    hours contributed
+                  </span>
+                </div>
+                <div className="flex items-center gap-1">
+                  <Briefcase className="h-4 w-4 text-green-600" />
+                  <span className="font-medium">{user.projectsCompleted}</span>
+                  <span className="text-muted-foreground">
+                    projects completed
+                  </span>
+                </div>
+              </div>
+
+              {/* Industries */}
+              <div className="flex items-center gap-2">
+                <span className="text-sm font-medium">Industries:</span>
+                <div className="flex gap-1">
+                  {user.industriesExperienced.map((industry) => (
+                    <Badge
+                      key={industry}
+                      variant="secondary"
+                      className="text-xs"
+                    >
+                      {industry}
+                    </Badge>
+                  ))}
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/components/profile/ProfileSidebar.tsx
+++ b/components/profile/ProfileSidebar.tsx
@@ -1,0 +1,98 @@
+"use client";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Button } from "@/components/ui/button";
+import { Avatar, AvatarFallback } from "@/components/ui/avatar";
+import { Globe, Users } from "lucide-react";
+import { Separator } from "../ui/separator";
+import { usePathname } from "next/navigation";
+
+export function ProfileSidebar() {
+  const pathname = usePathname();
+
+  const peopleYouMayKnow = [
+    {
+      name: "Laylong U",
+      title: "Student at American University of Phnom Penh",
+      mutualConnections: 12,
+    },
+    {
+      name: "Kimsun Seng",
+      title: "Student at American University of Phnom Penh",
+      mutualConnections: 8,
+    },
+    {
+      name: "Kimtong Peng",
+      title: "GIS & GeoIT Receptionist at Sungkyunkwan University",
+      mutualConnections: 5,
+    },
+  ];
+
+  return (
+    <div className="space-y-6">
+      {/* Profile Settings */}
+      <Card>
+        <CardContent className="space-y-4">
+          <div className="flex items-center justify-between">
+            <span className="text-sm font-semibold">Profile language</span>
+            <Button
+              variant="ghost"
+              size="sm"
+              className="h-auto p-0 text-muted-foreground"
+            >
+              English
+            </Button>
+          </div>
+          <Separator className="my-5" />
+          <div className="flex items-center justify-between">
+            <span className="text-sm font-semibold">Public profile & URL</span>
+            <Button
+              variant="ghost"
+              size="sm"
+              className="h-auto p-0 text-muted-foreground"
+            >
+              <Globe className="h-3 w-3" />
+            </Button>
+          </div>
+          <div>
+            <p>www.skillbridge.com{pathname}</p>
+          </div>
+        </CardContent>
+      </Card>
+
+      {/* People You May Know */}
+      <Card>
+        <CardHeader className="pb-3">
+          <CardTitle className="text-base">People you may know</CardTitle>
+          <p className="text-xs text-muted-foreground">From your profile</p>
+        </CardHeader>
+        <CardContent className="space-y-4">
+          {peopleYouMayKnow.map((person, index) => (
+            <div key={index} className="space-y-2">
+              <div className="flex items-start gap-3">
+                <Avatar className="w-10 h-10">
+                  <AvatarFallback className="bg-muted">
+                    {person.name[0]}
+                  </AvatarFallback>
+                </Avatar>
+                <div className="flex-1 min-w-0">
+                  <p className="text-sm font-medium">{person.name}</p>
+                  <p className="text-xs text-muted-foreground leading-tight">
+                    {person.title}
+                  </p>
+                </div>
+              </div>
+              <Button
+                variant="outline"
+                size="sm"
+                className="w-full text-xs bg-transparent"
+              >
+                <Users className="h-3 w-3 mr-1" />
+                Connect
+              </Button>
+            </div>
+          ))}
+        </CardContent>
+      </Card>
+    </div>
+  );
+}

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -87,12 +87,27 @@ enum SpecializationBadge {
   DATA_ANALYST_ACE // Completed multiple data analysis projects
   DESIGN_THINKER // Completed multiple UI/UX projects
   COMMUNITY_LEADER // Actively helps other students, maybe mentor role
+  CLOUD_SPECIALIST // Completed multiple cloud-related projects
+  MOBILE_MAVEN // Expert in mobile app development
+  AI_INNOVATOR // Specialized in AI/ML projects
+  CYBERSECURITY_CHAMP // Completed cybersecurity-focused projects
+  DEVOPS_GURU // Demonstrated DevOps expertise
+  DATABASE_WIZARD // Specialized in database design/management
+  FRONTEND_FOCUS // Specialized in frontend/UI development
+  BACKEND_BUILDER // Specialized in backend/API development
+  PRODUCT_MANAGER // Led or managed project teams
+  OPEN_SOURCE_CONTRIBUTOR // Significant contributions to open source projects
 }
 
 enum EngagementBadge {
   TOP_CONTRIBUTOR // Highly active, consistently takes projects
   MENTOR // Guides other students (if you build a mentorship feature)
   VETERAN // Completed a high number of projects/hours (e.g., 50 projects OR 200 hours)
+  EARLY_BIRD // Frequently among the first to apply or join projects
+  TEAM_PLAYER // Consistently collaborates well with others, positive feedback from teammates
+  INNOVATOR // Regularly suggests improvements or new ideas for projects/platform
+  COMMUNITY_HELPER // Actively answers questions or assists others in the community
+  CONSISTENT_PERFORMER // Maintains steady participation and quality over time
 }
 
 enum UserRole {


### PR DESCRIPTION
This pull request implements a complete user profile page, including a detailed mock user object, a structured layout, and three new React components to render the profile header, content, and sidebar. Additionally, it expands the badge enums in the Prisma schema to support a wider variety of specializations and engagement types.

The most important changes are:

**Profile Page Implementation:**

- Created a comprehensive mock user object in `app/profile/[userId]/page.tsx` with fields for bio, education, experience, projects, badges, and stats, and used it to render the profile page layout with `ProfileHeader`, `ProfileContent`, and `ProfileSidebar` components. ([app/profile/[userId]/page.tsxR1-R157](diffhunk://#diff-4dc12efcf67a574cc23dba8129d0e4a02d81faad9c08a0aa8bb6c256b9b293c6R1-R157))

**New Profile Components:**

- Added `ProfileHeader.tsx` to display the user's avatar, name, intro, location, badges, stats, and industries in a visually engaging header section.
- Added `ProfileContent.tsx` to render detailed sections for About, Experience, Education, and Projects, including formatting helpers for dates, durations, and status/budget display.
- Added `ProfileSidebar.tsx` to show profile settings and a "People you may know" section, with mock data and connect buttons.

**Database Schema Updates:**

- Expanded the `SpecializationBadge` and `EngagementBadge` enums in `prisma/schema.prisma` to include new badge types such as `CLOUD_SPECIALIST`, `AI_INNOVATOR`, `DEVOPS_GURU`, `EARLY_BIRD`, `TEAM_PLAYER`, and others, supporting richer user achievement tracking.