### PR TITLE
90 implement model action createproject for the project model

### DIFF
--- a/components/project/PostProjectModal.tsx
+++ b/components/project/PostProjectModal.tsx
@@ -158,12 +158,11 @@ export function PostProjectModal({
 
       const project = await createProject({
         ...formDataWithSkills,
-        status: "OPEN", // or a valid status
-        isPublic: true, // or true based on your logic
-        createdAt: new Date(), // or a valid date
-        assignedStudent: undefined, // or a valid student ID if applicable
+        status: "OPEN",
+        isPublic: true,
+        createdAt: new Date(),
+        assignedStudent: undefined,
         businessOwner: { connect: { id: dbUser.id } },
-        updatedAt: new Date(),
       });
 
       console.log("Project successfully created, ", project);

--- a/lib/actions/project.ts
+++ b/lib/actions/project.ts
@@ -1,0 +1,32 @@
+"use server";
+
+import { currentUser } from "@clerk/nextjs/server";
+import { Prisma } from "@prisma/client";
+import prisma from "../prisma";
+
+export async function createProject(projectData: Prisma.ProjectCreateInput) {
+  const user = await currentUser();
+  console.log(projectData);
+
+  if (!user) throw new Error("Not authenticated.");
+
+  try {
+    const currentUser = await prisma.user.findFirst({
+      where: { clerkId: user.id },
+    });
+
+    if (!currentUser) throw new Error("User not found.");
+    if (currentUser.role !== "BUSINESS_OWNER")
+      throw new Error("User can not create a project.");
+
+    const project = await prisma.project.create({
+      data: projectData,
+    });
+
+    console.log("Project successfully created.");
+    return project;
+  } catch (e) {
+    console.error("Error creating new project, ", e);
+    throw new Error("Failed to create new project.");
+  }
+}

--- a/lib/actions/project.ts
+++ b/lib/actions/project.ts
@@ -6,7 +6,6 @@ import prisma from "../prisma";
 
 export async function createProject(projectData: Prisma.ProjectCreateInput) {
   const user = await currentUser();
-  console.log(projectData);
 
   if (!user) throw new Error("Not authenticated.");
 


### PR DESCRIPTION
This pull request introduces backend integration for project creation in the `PostProjectModal` component, ensuring that only authenticated business owners can create new projects. It refactors category and scope selection to use enums from the database schema, and adds robust error handling and user validation. The most important changes are grouped below.

**Backend integration and validation:**

* Added a new `createProject` function in `lib/actions/project.ts` that creates a project in the database, validating that the user is authenticated and has the `BUSINESS_OWNER` role.
* Updated the `handleSubmit` function in `PostProjectModal.tsx` to call `createProject` and fetch the current user from the backend, ensuring only signed-in users can submit projects. [[1]](diffhunk://#diff-29ce2c1651ec99d45ec4728fe44c3d90c21be501d58b7b011e725777e93eb10cL153-R172) [[2]](diffhunk://#diff-29ce2c1651ec99d45ec4728fe44c3d90c21be501d58b7b011e725777e93eb10cR130)

**Refactoring and consistency:**

* Refactored `categories` and `scopes` in `PostProjectModal.tsx` to use enum values from the Prisma schema (`ProjectCategory` and `ProjectScope`), ensuring consistency with backend data.