### PR TITLE
Feature: add editing server action to project model

### DIFF
--- a/lib/actions/project.ts
+++ b/lib/actions/project.ts
@@ -54,3 +54,32 @@ export async function createProject(projectData: Prisma.ProjectCreateInput) {
     throw new Error("Failed to create new project.");
   }
 }
+
+export async function editProject(
+  projectData: Prisma.ProjectCreateInput,
+  projectId: string
+) {
+  const user = await currentUser();
+
+  if (!user) throw new Error("User not authenticated.");
+
+  try {
+    const existingUser = await prisma.user.findFirst({
+      where: { clerkId: user.id },
+    });
+
+    if (!existingUser) throw new Error("User not found.");
+    if (existingUser.role !== "BUSINESS_OWNER")
+      throw new Error("This role is now allowed to call this function.");
+
+    const project = await prisma.project.update({
+      where: { id: projectId },
+      data: projectData,
+    });
+
+    return project;
+  } catch (e) {
+    console.error("Error updating project data, ", e);
+    throw new Error("Failed to updated project data.");
+  }
+}


### PR DESCRIPTION
This pull request adds the ability for users to edit their posted projects and improves the logic for creating and updating projects. The changes ensure proper user authentication and ownership checks when editing or creating projects.

**Enhancements to project creation and editing:**

* Added a new `editProject` function in `lib/actions/project.ts` that allows authenticated business owners to update their projects, with role and user checks for security.
* Updated `UserPostedProjects` component to use the new `editProject` and `createProject` functions, ensuring that only signed-in users can create or edit projects and that the correct business owner is associated with the project. [[1]](diffhunk://#diff-2ee0b54c9771aa91d17e8a9f6bca0b5758de050f0f743d1e280653b0373b48fdR28-R39) [[2]](diffhunk://#diff-2ee0b54c9771aa91d17e8a9f6bca0b5758de050f0f743d1e280653b0373b48fdL117-R154)

**Improved user authentication and data flow:**

* Integrated `useUser` from Clerk and `getUserByClerkId` to fetch and verify the current user before allowing project creation or editing, ensuring only authorized actions are performed. [[1]](diffhunk://#diff-2ee0b54c9771aa91d17e8a9f6bca0b5758de050f0f743d1e280653b0373b48fdR28-R39) [[2]](diffhunk://#diff-2ee0b54c9771aa91d17e8a9f6bca0b5758de050f0f743d1e280653b0373b48fdL117-R154)