### PR TITLE
201 display count of unresponded applications next to user button in header

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -120,3 +120,9 @@
     @apply bg-background text-foreground;
   }
 }
+
+.cl-avatarBox {
+  width: 2.25rem;
+  height: 2.25rem;
+  border-radius: 0.5rem;
+}

--- a/components/Header.tsx
+++ b/components/Header.tsx
@@ -1,10 +1,14 @@
 import { getUser, isAuthenticated } from "@/lib/actions/user";
 import HeaderContent from "./HeaderContent";
+import { getTotalUnrespondedApplication } from "@/lib/actions/application";
 
 const Header = async () => {
   const authenticated = await isAuthenticated();
   const user = authenticated ? await getUser() : null;
-  return <HeaderContent user={user} />;
+  const applications = await getTotalUnrespondedApplication();
+  return (
+    <HeaderContent user={user} totalUnrespondedApplications={applications} />
+  );
 };
 
 export default Header;

--- a/components/HeaderContent.tsx
+++ b/components/HeaderContent.tsx
@@ -24,9 +24,13 @@ import { OrganizationApplication } from "./setting/OrganizationApplication";
 
 interface HeaderContentProps {
   user: User | null;
+  totalUnrespondedApplications: number | 0;
 }
 
-const HeaderContent: React.FC<HeaderContentProps> = ({ user }) => {
+const HeaderContent: React.FC<HeaderContentProps> = ({
+  user,
+  totalUnrespondedApplications,
+}) => {
   const pathname = usePathname();
   const [isModalOpen, setIsModalOpen] = useState(false);
 
@@ -67,56 +71,61 @@ const HeaderContent: React.FC<HeaderContentProps> = ({ user }) => {
               </div>
             )}
 
-            <UserButton>
-              <UserButton.UserProfilePage
-                label="Bio"
-                url="bio"
-                labelIcon={<ScanFace className="w-4 h-4" />}
-              >
-                <UserInformation />
-              </UserButton.UserProfilePage>
-              <UserButton.UserProfilePage
-                label="Experience"
-                url="experience"
-                labelIcon={<BriefcaseBusiness className="w-4 h-4" />}
-              >
-                <UserExperience />
-              </UserButton.UserProfilePage>
-              <UserButton.UserProfilePage
-                label="Education"
-                url="education"
-                labelIcon={<GraduationCap className="w-4 h-4" />}
-              >
-                <UserEducation />
-              </UserButton.UserProfilePage>
-              {user?.role === "USER" && (
+            <div className="relative pt-2">
+              <div className="absolute top-0 -right-2 w-5 h-5 z-50 bg-red-400 rounded-full text-white font-bold text-xs flex items-center justify-center">
+                {totalUnrespondedApplications}
+              </div>
+              <UserButton>
                 <UserButton.UserProfilePage
-                  label="Applications"
-                  url="applications"
-                  labelIcon={<ScrollText className="w-4 h-4" />}
+                  label="Bio"
+                  url="bio"
+                  labelIcon={<ScanFace className="w-4 h-4" />}
                 >
-                  <UserApplications />
+                  <UserInformation />
                 </UserButton.UserProfilePage>
-              )}
-              {user?.role === "BUSINESS_OWNER" && (
                 <UserButton.UserProfilePage
-                  label="Posted Projects"
-                  url="projects"
-                  labelIcon={<FolderClock className="w-4 h-4" />}
+                  label="Experience"
+                  url="experience"
+                  labelIcon={<BriefcaseBusiness className="w-4 h-4" />}
                 >
-                  <OrganizationPostedProjects />
+                  <UserExperience />
                 </UserButton.UserProfilePage>
-              )}
-              {user?.role === "BUSINESS_OWNER" && (
                 <UserButton.UserProfilePage
-                  label="Applications"
-                  url="applications"
-                  labelIcon={<ScrollText className="w-4 h-4" />}
+                  label="Education"
+                  url="education"
+                  labelIcon={<GraduationCap className="w-4 h-4" />}
                 >
-                  <OrganizationApplication />
+                  <UserEducation />
                 </UserButton.UserProfilePage>
-              )}
-            </UserButton>
+                {user?.role === "USER" && (
+                  <UserButton.UserProfilePage
+                    label="Applications"
+                    url="applications"
+                    labelIcon={<ScrollText className="w-4 h-4" />}
+                  >
+                    <UserApplications />
+                  </UserButton.UserProfilePage>
+                )}
+                {user?.role === "BUSINESS_OWNER" && (
+                  <UserButton.UserProfilePage
+                    label="Posted Projects"
+                    url="projects"
+                    labelIcon={<FolderClock className="w-4 h-4" />}
+                  >
+                    <OrganizationPostedProjects />
+                  </UserButton.UserProfilePage>
+                )}
+                {user?.role === "BUSINESS_OWNER" && (
+                  <UserButton.UserProfilePage
+                    label="Applications"
+                    url="applications"
+                    labelIcon={<ScrollText className="w-4 h-4" />}
+                  >
+                    <OrganizationApplication />
+                  </UserButton.UserProfilePage>
+                )}
+              </UserButton>
+            </div>
           </div>
         </SignedIn>
       </div>


### PR DESCRIPTION
This pull request introduces a new feature for business owners to view the count of unresponded (pending) applications directly in the header, along with supporting backend logic and minor UI enhancements. The changes span both frontend and backend code, focusing on improving visibility and user experience for business owners.

### New feature: Display unresponded applications count in header

* Added a red badge to the header UI (`HeaderContent.tsx`) that shows the number of unresponded applications for business owners. [[1]](diffhunk://#diff-6671ffc70c83206ad55e1edb2725c7a7bd9a8732dde3f3263cd81a403228b514R74-R77) [[2]](diffhunk://#diff-6671ffc70c83206ad55e1edb2725c7a7bd9a8732dde3f3263cd81a403228b514R27-R33)
* Updated the `Header` component to fetch the total unresponded applications and pass the count to `HeaderContent`.

### Backend support for unresponded applications count

* Implemented `getTotalUnrespondedApplication` in `application.ts`, which returns the count of pending applications for the current business owner, with appropriate error handling and role checks.

### UI and style improvements

* Added `.cl-avatarBox` CSS class for consistent avatar sizing and rounding in the global stylesheet.

### Data consistency after application actions

* Added `revalidatePath("/")` to both `approveApplication` and `rejectApplication` functions to ensure the UI updates immediately after an application is approved or rejected. [[1]](diffhunk://#diff-7f34b41e8079fd6b380d87f37faea631bb9605a8c0f58cf5d8be26ea46ef89aaL163-R211) [[2]](diffhunk://#diff-7f34b41e8079fd6b380d87f37faea631bb9605a8c0f58cf5d8be26ea46ef89aaL206-R251)