### PR TITLE
221 hide experience and education tabs for organization accounts in manage account

### DIFF
--- a/components/HeaderContent.tsx
+++ b/components/HeaderContent.tsx
@@ -88,20 +88,24 @@ const HeaderContent: React.FC<HeaderContentProps> = ({
                 >
                   <UserInformation />
                 </UserButton.UserProfilePage>
-                <UserButton.UserProfilePage
-                  label="Experience"
-                  url="experience"
-                  labelIcon={<BriefcaseBusiness className="w-4 h-4" />}
-                >
-                  <UserExperience />
-                </UserButton.UserProfilePage>
-                <UserButton.UserProfilePage
-                  label="Education"
-                  url="education"
-                  labelIcon={<GraduationCap className="w-4 h-4" />}
-                >
-                  <UserEducation />
-                </UserButton.UserProfilePage>
+                {user?.role === "USER" && (
+                  <UserButton.UserProfilePage
+                    label="Experience"
+                    url="experience"
+                    labelIcon={<BriefcaseBusiness className="w-4 h-4" />}
+                  >
+                    <UserExperience />
+                  </UserButton.UserProfilePage>
+                )}
+                {user?.role === "USER" && (
+                  <UserButton.UserProfilePage
+                    label="Education"
+                    url="education"
+                    labelIcon={<GraduationCap className="w-4 h-4" />}
+                  >
+                    <UserEducation />
+                  </UserButton.UserProfilePage>
+                )}
                 {user?.role === "USER" && (
                   <UserButton.UserProfilePage
                     label="Applications"


### PR DESCRIPTION
This pull request introduces a conditional rendering update to the `HeaderContent` component, ensuring that only users with the "USER" role see the "Experience" and "Education" profile sections. This change improves the user experience by showing relevant profile options based on user roles.

Role-based UI updates:

* In `components/HeaderContent.tsx`, wrapped the "Experience" and "Education" profile page buttons in a conditional check so that only users with the "USER" role will see these sections.