### PR TITLE
181 fix inconsistent project card width when title spans multiple lines

### DIFF
--- a/components/browse/ProjectCard.tsx
+++ b/components/browse/ProjectCard.tsx
@@ -164,7 +164,7 @@ export function ProjectCard({
                     <Badge className="bg-[#695DCC]">{project.scope}</Badge>
                   </div>
                   {/* Project Title */}
-                  <h3 className="text-lg font-bold text-gray-900 mb-3 line-clamp-2 leading-relaxed">
+                  <h3 className="text-lg font-bold text-gray-900 mb-3 line-clamp-1 overflow-clip leading-relaxed">
                     {project.title}
                   </h3>
                   <div className="h-20 overflow-clip">


### PR DESCRIPTION
This pull request makes a minor UI adjustment to the project title display in the `ProjectCard` component. The change limits the project title to a single line and clips any overflow for improved visual consistency.

* Changed the project title in `ProjectCard` to use `line-clamp-1` and `overflow-clip`, ensuring titles are displayed on a single line and clipped if too long.