### PR TITLE
239 fix scroll arrows and tag overflow in project cards

### DIFF
--- a/components/browse/ProjectCard.tsx
+++ b/components/browse/ProjectCard.tsx
@@ -173,7 +173,7 @@ export function ProjectCard({
                     </p>
                   </div>
 
-                  <div className="flex items-center gap-1 mt-5 overflow-scroll">
+                  <div className="flex items-center gap-1 mt-5 overflow-y-clip  overflow-x-scroll">
                     {project.requiredSkills.map((skill) => (
                       <Badge key={skill} variant={"outline"}>
                         {skill}


### PR DESCRIPTION
This pull request makes a minor update to the scroll behavior of the skills badge container in the `ProjectCard` component. The change improves the visual handling of overflow for the skills list.

* Updated the container for required skills badges in `ProjectCard.tsx` to use `overflow-y-clip` and `overflow-x-scroll` for better horizontal scrolling and to prevent vertical overflow.