### PR TITLE
238 fix budget range slider and filtering logic

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -13,7 +13,7 @@ export default async function MarketplacePage({
   const categories = ((await searchParams).categories as string) || "";
   const scopes = ((await searchParams).scopes as string) || "";
   const minBudget = ((await searchParams).minBudget as string) || "";
-  const maxBudget = ((await searchParams).maxbudget as string) || "";
+  const maxBudget = ((await searchParams).maxBudget as string) || "";
 
   const { availableProjects, totalProjects } = await getAvailableProjects(
     query,


### PR DESCRIPTION
This pull request includes a small fix to the way the maximum budget parameter is read from the search parameters in the `MarketplacePage` component. The change ensures that the correct casing (`maxBudget` instead of `maxbudget`) is used to retrieve the value.