### PR TITLE
223 add previous projects tab for students in user settings

### DIFF
--- a/app/profile/[userId]/page.tsx
+++ b/app/profile/[userId]/page.tsx
@@ -2,6 +2,7 @@ import { ProfileContent } from "@/components/profile/ProfileContent";
 import { ProfileHeader } from "@/components/profile/ProfileHeader";
 import ProfileNotFoundPage from "@/components/profile/ProfileNotFound";
 import { ProfileSidebar } from "@/components/profile/ProfileSidebar";
+import { getCompletedProjectsByAssignedStudentId } from "@/lib/actions/project";
 import { getUserByClerkId } from "@/lib/actions/user";
 
 interface ProfilePageProps {
@@ -13,6 +14,9 @@ interface ProfilePageProps {
 export default async function ProfilePage({ params }: ProfilePageProps) {
   const { userId } = await params;
   const userData = await getUserByClerkId(userId);
+  const completedProjects = await getCompletedProjectsByAssignedStudentId(
+    userId
+  );
 
   if (!userData) {
     return <ProfileNotFoundPage />;
@@ -23,7 +27,7 @@ export default async function ProfilePage({ params }: ProfilePageProps) {
         <ProfileHeader user={userData} />
         <div className="grid grid-cols-1 lg:grid-cols-4 gap-6 px-4 pb-8">
           <div className="lg:col-span-3">
-            <ProfileContent user={userData} />
+            <ProfileContent user={userData} projects={completedProjects} />
           </div>
           <div className="lg:col-span-1">
             <ProfileSidebar />

--- a/components/profile/ProfileContent.tsx
+++ b/components/profile/ProfileContent.tsx
@@ -1,5 +1,5 @@
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
-import { User } from "@prisma/client";
+import { Project, User } from "@prisma/client";
 
 import {
   Building2,
@@ -9,6 +9,7 @@ import {
   Clock,
 } from "lucide-react";
 import Link from "next/link";
+import { Badge } from "../ui/badge";
 
 // Check if a string has non-empty text and array with at least 1 element
 const hasText = (v?: string | null): v is string =>
@@ -16,9 +17,10 @@ const hasText = (v?: string | null): v is string =>
 
 interface ProfileContentProps {
   user: User;
+  projects: Project[];
 }
 
-export function ProfileContent({ user }: ProfileContentProps) {
+export function ProfileContent({ user, projects }: ProfileContentProps) {
   const formatDate = (date: Date) => {
     return date.toLocaleDateString("en-US", {
       month: "short",
@@ -176,8 +178,8 @@ export function ProfileContent({ user }: ProfileContentProps) {
               <CardTitle className="text-lg">Projects</CardTitle>
             </CardHeader>
             <CardContent className="space-y-6">
-              {user.previousProjects.length > 0 ? (
-                user.previousProjects.map((project, index) => (
+              {projects.length > 0 ? (
+                projects.map((project, index) => (
                   <div key={project.id} className="flex gap-4">
                     <div className="w-12 h-12 bg-muted rounded-lg flex items-center justify-center flex-shrink-0">
                       <FolderOpen className="h-6 w-6 text-muted-foreground" />
@@ -186,40 +188,40 @@ export function ProfileContent({ user }: ProfileContentProps) {
                     <div className="flex-1 min-w-0">
                       <div className="flex items-start justify-between gap-4">
                         <div className="flex-1">
-                          <h3 className="font-semibold text-balance">
-                            {project.title}
-                          </h3>
+                          <div className="flex items-center justify-between">
+                            <h3 className="font-semibold text-balance">
+                              {project.title}
+                            </h3>
+                            <div className="flex items-center gap-1 text-sm text-muted-foreground mt-2">
+                              <span>
+                                {formatDate(project.startDate)} -{" "}
+                                {project.estimatedEndDate
+                                  ? formatDate(project.estimatedEndDate)
+                                  : "Present"}
+                              </span>
+                            </div>
+                          </div>
                           <div className="flex items-center gap-2 mt-1">
-                            <span className="text-sm text-muted-foreground">
-                              {formatStatus(project.industry)}
-                            </span>
+                            <Badge variant={"outline"}>
+                              {formatStatus(project.category)}
+                            </Badge>
+                            <Badge variant={"outline"}>
+                              {formatStatus(project.scope)}
+                            </Badge>
                           </div>
                         </div>
-                      </div>
-
-                      <div className="flex items-center gap-1 text-sm text-muted-foreground mt-2">
-                        <Clock className="h-3 w-3" />
-                        <span>
-                          {formatDate(project.startDate)} -{" "}
-                          {project.endDate
-                            ? formatDate(project.endDate)
-                            : "Present"}
-                        </span>
                       </div>
 
                       <p className="text-sm text-muted-foreground mt-2 leading-relaxed">
                         {project.description}
                       </p>
 
-                      {project.tags.length > 0 && (
+                      {project.requiredSkills.length > 0 && (
                         <div className="flex flex-wrap gap-2 mt-3">
-                          {project.tags.map((skill, skillIndex) => (
-                            <span
-                              key={skillIndex}
-                              className="px-2 py-1 bg-muted rounded-md text-xs font-medium text-muted-foreground"
-                            >
+                          {project.requiredSkills.map((skill, skillIndex) => (
+                            <Badge key={skillIndex} variant={"outline"}>
                               {skill}
-                            </span>
+                            </Badge>
                           ))}
                         </div>
                       )}

--- a/lib/actions/project.ts
+++ b/lib/actions/project.ts
@@ -131,6 +131,43 @@ export async function getProjectsByOwnerId() {
   }
 }
 
+export async function getCompletedProjectsByAssignedStudentId(userId: string) {
+  try {
+    const user = await prisma.user.findFirst({
+      where: { clerkId: userId },
+    });
+
+    if (!user) throw new Error("User not found.");
+
+    const completedProjects = await prisma.project.findMany({
+      where: {
+        assignedStudentId: user.id,
+        status: "COMPLETED",
+      },
+      include: {
+        businessOwner: {
+          select: {
+            id: true,
+            imageUrl: true,
+            firstName: true,
+            lastName: true,
+            address: true,
+            bio: true,
+            intro: true,
+          },
+        },
+      },
+      orderBy: {
+        completedAt: "desc",
+      },
+    });
+
+    return completedProjects;
+  } catch (e) {
+    console.error("Error fetching completed projects, ", e);
+    throw new Error("Failed to fetch completed projects.");
+  }
+}
 export async function getProjectByProjectId(projectId: string) {
   try {
     const project = await prisma.project.findUnique({


### PR DESCRIPTION
This pull request adds functionality to display completed projects assigned to a student on their profile page. The main changes involve fetching completed projects from the backend, passing them to the profile content component, and updating the UI to show relevant project details using improved badges and fields.

**Backend integration:**

* Added a new function `getCompletedProjectsByAssignedStudentId` in `lib/actions/project.ts` to fetch completed projects for a given student, including business owner details and ordering by completion date.

**Profile page data flow:**

* Updated `app/profile/[userId]/page.tsx` to fetch completed projects using the new backend function and pass them as a prop to `ProfileContent`. ([app/profile/[userId]/page.tsxR5](diffhunk://#diff-4dc12efcf67a574cc23dba8129d0e4a02d81faad9c08a0aa8bb6c256b9b293c6R5), [app/profile/[userId]/page.tsxR17-R19](diffhunk://#diff-4dc12efcf67a574cc23dba8129d0e4a02d81faad9c08a0aa8bb6c256b9b293c6R17-R19), [app/profile/[userId]/page.tsxL26-R30](diffhunk://#diff-4dc12efcf67a574cc23dba8129d0e4a02d81faad9c08a0aa8bb6c256b9b293c6L26-R30))

**Profile content UI improvements:**

* Modified `ProfileContent` in `components/profile/ProfileContent.tsx` to accept and display the `projects` prop, replacing previous logic that used `user.previousProjects`. [[1]](diffhunk://#diff-6fd86469a04beef97ea9f7cd059ec5909128e222cb33d7033c252757255d38fbL2-R2) [[2]](diffhunk://#diff-6fd86469a04beef97ea9f7cd059ec5909128e222cb33d7033c252757255d38fbR12-R23) [[3]](diffhunk://#diff-6fd86469a04beef97ea9f7cd059ec5909128e222cb33d7033c252757255d38fbL179-R182)
* Enhanced project display: replaced industry and tags with category, scope, and required skills badges, and updated date fields to use `estimatedEndDate` for completed projects.