### PR TITLE
263 allow users to edit their username

### DIFF
--- a/components/setting/UserInformation.tsx
+++ b/components/setting/UserInformation.tsx
@@ -174,10 +174,31 @@ export function UserInformation() {
                 <div className="flex-1 space-y-2">
                   {isEditing ? (
                     <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
-                      <div className="md:col-span-2">
-                        <h1 className="font-bold text-balance text-muted-foreground">
-                          {displayData.firstName} {displayData.lastName}
-                        </h1>
+                      <div>
+                        <Label className="text-sm font-semibold">
+                          First Name
+                        </Label>
+                        <Input
+                          value={editingData.firstName || ""}
+                          onChange={(e) =>
+                            handleInputChange("firstName", e.target.value)
+                          }
+                          placeholder="Enter first name"
+                          className="mt-2"
+                        />
+                      </div>
+                      <div>
+                        <Label className="text-sm font-semibold">
+                          Last Name
+                        </Label>
+                        <Input
+                          value={editingData.lastName || ""}
+                          onChange={(e) =>
+                            handleInputChange("lastName", e.target.value)
+                          }
+                          placeholder="Enter last name"
+                          className="mt-2"
+                        />
                       </div>
                     </div>
                   ) : (
@@ -199,13 +220,13 @@ export function UserInformation() {
                       <Briefcase className="w-3 h-3 mr-1" />
                       {displayData.role}
                     </Badge>
-                  {displayData.role !== "BUSINESS_OWNER" && (
-                    <Badge
-                      variant={displayData.occupied ? "default" : "outline"}
-                    >
-                      {displayData.occupied ? "Available" : "Busy"}
-                    </Badge>
-                  )}
+                    {displayData.role !== "BUSINESS_OWNER" && (
+                      <Badge
+                        variant={displayData.occupied ? "default" : "outline"}
+                      >
+                        {displayData.occupied ? "Available" : "Busy"}
+                      </Badge>
+                    )}
                   </div>
                 </div>
               </div>
@@ -300,31 +321,31 @@ export function UserInformation() {
                   </p>
                 )}
               </div>
-          {displayData.role !== "BUSINESS_OWNER" && (
-            <div>
-              <Label className="text-sm font-semibold">Status</Label>
-              {isEditing ? (
-                <Select
-                  value={editingData.occupied ? "Available" : "Busy"}
-                  onValueChange={(value) =>
-                    handleInputChange("occupied", value === "Available")
-                  }
-                >
-                  <SelectTrigger className="mt-2">
-                    <SelectValue />
-                  </SelectTrigger>
-                  <SelectContent>
-                    <SelectItem value="Available">Available</SelectItem>
-                    <SelectItem value="Busy">Busy</SelectItem>
-                  </SelectContent>
-                </Select>
-              ) : (
-                <p className="text-sm mt-2 text-muted-foreground">
-                  {displayData.occupied ? "Available" : "Busy"}
-                </p>
+              {displayData.role !== "BUSINESS_OWNER" && (
+                <div>
+                  <Label className="text-sm font-semibold">Status</Label>
+                  {isEditing ? (
+                    <Select
+                      value={editingData.occupied ? "Available" : "Busy"}
+                      onValueChange={(value) =>
+                        handleInputChange("occupied", value === "Available")
+                      }
+                    >
+                      <SelectTrigger className="mt-2">
+                        <SelectValue />
+                      </SelectTrigger>
+                      <SelectContent>
+                        <SelectItem value="Available">Available</SelectItem>
+                        <SelectItem value="Busy">Busy</SelectItem>
+                      </SelectContent>
+                    </Select>
+                  ) : (
+                    <p className="text-sm mt-2 text-muted-foreground">
+                      {displayData.occupied ? "Available" : "Busy"}
+                    </p>
+                  )}
+                </div>
               )}
-            </div>
-          )}
             </div>
           </div>
 
@@ -430,7 +451,9 @@ export function UserInformation() {
                           <div className="flex items-center bg-secondary rounded-md">
                             <Input
                               value={skill}
-                              onChange={(e) => updateSkill(index, e.target.value)}
+                              onChange={(e) =>
+                                updateSkill(index, e.target.value)
+                              }
                               className="w-32 h-8 border-0 bg-transparent focus-visible:ring-0 focus-visible:ring-offset-0"
                             />
                             <Button
@@ -457,4 +480,3 @@ export function UserInformation() {
     </div>
   );
 }
-


### PR DESCRIPTION
This pull request updates the user information editing form in `UserInformation.tsx` to improve usability and clarity. The main change is splitting the full name field into separate editable fields for first and last name, providing a more granular editing experience. Minor formatting and code style improvements are also included.

**User information form improvements:**

* Replaced the single full name display and edit field with separate `First Name` and `Last Name` input fields, allowing users to edit each part of their name individually. (`UserInformation.tsx`, [components/setting/UserInformation.tsxL177-R201](diffhunk://#diff-fd7aef4d5f6f89dbf3193862ad39a9f0c1cad90b15a63f3af3f0642d23bd0786L177-R201))

**Code style and formatting:**

* Reformatted the skill input field’s `onChange` handler for better readability. (`UserInformation.tsx`, [components/setting/UserInformation.tsxL433-R456](diffhunk://#diff-fd7aef4d5f6f89dbf3193862ad39a9f0c1cad90b15a63f3af3f0642d23bd0786L433-R456))
* Removed an unnecessary trailing newline at the end of the file. (`UserInformation.tsx`, [components/setting/UserInformation.tsxL460](diffhunk://#diff-fd7aef4d5f6f89dbf3193862ad39a9f0c1cad90b15a63f3af3f0642d23bd0786L460))