### PR TITLE
261 fix project search pagination next page button does not update content

### DIFF
--- a/lib/actions/project.ts
+++ b/lib/actions/project.ts
@@ -24,13 +24,9 @@ export async function getAvailableProjects(
   maxBudget: string
 ) {
   const pageSize = 6;
-  // Determine the skip value based on the presence of a query
-  let skip: number;
-  if (query) {
-    skip = 0; // If there's a query, reset to the first page (skip 0)
-  } else {
-    skip = Math.abs(pageSize * (Number(page) - 1)); // Otherwise, calculate skip based on the provided page
-  }
+  // Calculate skip value based on the current page
+  const currentPage = Number(page) || 1;
+  const skip = Math.abs(pageSize * (currentPage - 1));
 
   const categoryList =
     categories.length > 0


### PR DESCRIPTION
This pull request simplifies the logic for calculating the pagination offset (`skip`) in the `getAvailableProjects` function. The new implementation consistently computes the skip value based on the current page, removing the conditional logic that previously reset the skip when a query was present.

Pagination logic simplification:

* Refactored the calculation of the `skip` value to always use the current page number, removing the special case for when a query is provided. This makes the pagination behavior more predictable and easier to maintain. (`lib/actions/project.ts`, [lib/actions/project.tsL27-R29](diffhunk://#diff-47105d165ceef5aacb02c00fdcbc6d3bbeacd77e871d897b8bbb6d5138c83147L27-R29))