### PR TITLE
Fix: filter out draft projects

### DIFF
--- a/lib/actions/project.ts
+++ b/lib/actions/project.ts
@@ -39,7 +39,7 @@ export async function getAvailableProjects(
   try {
     const totalProjects = await prisma.project.count({
       where: {
-        status: { not: "ARCHIVED" },
+        status: { notIn: ["ARCHIVED", "DRAFT"] },
         title: { contains: query, mode: "insensitive" },
         category: { in: categoryList },
         scope: { in: scopeList },
@@ -53,7 +53,7 @@ export async function getAvailableProjects(
       skip: skip,
       take: pageSize,
       where: {
-        status: { not: "ARCHIVED" },
+        status: { notIn: ["ARCHIVED", "DRAFT"] },
         title: { contains: query, mode: "insensitive" },
         category: { in: categoryList },
         scope: { in: scopeList },


### PR DESCRIPTION
This pull request makes a small but important change to the project listing logic. It updates the filtering criteria so that both "ARCHIVED" and "DRAFT" projects are excluded from available project queries, rather than just "ARCHIVED" projects. This ensures users only see projects that are active and ready.