### PR TITLE
277 add notification for applications section in account sidebar

### DIFF
--- a/components/HeaderContent.tsx
+++ b/components/HeaderContent.tsx
@@ -142,7 +142,17 @@ const HeaderContent: React.FC<HeaderContentProps> = ({
                   <UserButton.UserProfilePage
                     label="Applications"
                     url="applications"
-                    labelIcon={<ScrollText className="w-4 h-4" />}
+                    labelIcon={
+                      <>
+                        <ScrollText className="w-4 h-4" />{" "}
+                        {totalUnrespondedApplications &&
+                          totalUnrespondedApplications > 0 && (
+                            <div className="absolute top-0 -right-28 w-4 h-4 z-50 bg-red-400 rounded-full text-white font-bold text-[10px] flex items-center justify-center">
+                              {totalUnrespondedApplications}
+                            </div>
+                          )}
+                      </>
+                    }
                   >
                     <OrganizationApplication />
                   </UserButton.UserProfilePage>

--- a/components/browse/ProjectCard.tsx
+++ b/components/browse/ProjectCard.tsx
@@ -30,7 +30,6 @@ import { ApplyButton } from "../application/ApplyButton";
 import { useUserAuth } from "@/lib/stores/userStore";
 import { getCategoryThumbnail } from "@/lib/categoryThumbnails";
 import { User } from "@prisma/client";
-import { getUserByClerkId } from "@/lib/actions/user";
 import Link from "next/link";
 
 interface ProjectCardProps {


### PR DESCRIPTION
This pull request introduces a UI improvement to the applications section in the user profile and includes a minor code cleanup in the project card component.

UI enhancement:

* Added a notification badge to the `Applications` tab in the user profile (`HeaderContent.tsx`). The badge displays the number of unresponded applications if there are any, making it easier for users to spot pending actions.

Code cleanup:

* Removed an unused import of `getUserByClerkId` from `ProjectCard.tsx`, simplifying the code.