### PR TITLE
291 allow users to unarchive images

### DIFF
--- a/components/HeaderContent.tsx
+++ b/components/HeaderContent.tsx
@@ -61,11 +61,19 @@ const HeaderContent: React.FC<HeaderContentProps> = ({
       <div className="text-gray-100 max-w-lg min-w-md">
         <SearchBar />
       </div>
-      <div>
+      <div className="flex items-center gap-2">
+        <Link href={"/sign-in"}>
+          <Button
+            variant={"ghost"}
+            className="text-white font-medium rounded-full hover:bg-[#695DCC]/40 hover:text-white"
+          >
+            Sign in
+          </Button>
+        </Link>
         <SignedOut>
           <Link href="/sign-up">
-            <Button className="cursor-pointer bg-[#695DCC] hover:bg-[#695DCC]/80 font-bold">
-              Sign Up
+            <Button className="cursor-pointer bg-[#695DCC] hover:bg-[#695DCC]/80 font-semibold rounded-full">
+              Get Started
             </Button>
           </Link>
         </SignedOut>

--- a/components/browse/ProjectCard.tsx
+++ b/components/browse/ProjectCard.tsx
@@ -99,7 +99,7 @@ export function ProjectCard({
   return (
     <div className="container mx-auto">
       <div className="w-full flex items-center justify-between px-6 mt-5">
-        <h1 className="font-bold text-lg">Available Projects</h1>
+        <h1 className="font-semibold text-lg">Available Projects</h1>
         <div className="flex items-center">
           <Button
             variant="outline"


### PR DESCRIPTION
This pull request adds support for unarchiving projects, allowing business owners to restore archived projects to an open status and make them visible to applicants again. The changes include backend logic for unarchiving, updates to the project detail UI to support both archiving and unarchiving actions, and improvements to button styling and dialog messaging for clarity.

**Unarchive functionality:**

* Added the `unarchiveProject` function in `lib/actions/project.ts` to allow business owners to restore archived projects to "OPEN" status, with authentication and role checks, and page revalidation.
* Updated `components/project/ProjectDetail.tsx` to handle unarchiving in the UI, including a new handler, dialog messaging, and conditional rendering of "Unarchive" and "Archive" buttons. [[1]](diffhunk://#diff-5579fb43aff3bf7cfd1ba4e7c895b722d7a22eaf171bf0e88203a78aa48ef58eL21-R25) [[2]](diffhunk://#diff-5579fb43aff3bf7cfd1ba4e7c895b722d7a22eaf171bf0e88203a78aa48ef58eL132-R157) [[3]](diffhunk://#diff-5579fb43aff3bf7cfd1ba4e7c895b722d7a22eaf171bf0e88203a78aa48ef58eR216-R226) [[4]](diffhunk://#diff-5579fb43aff3bf7cfd1ba4e7c895b722d7a22eaf171bf0e88203a78aa48ef58eR236) [[5]](diffhunk://#diff-5579fb43aff3bf7cfd1ba4e7c895b722d7a22eaf171bf0e88203a78aa48ef58eL427-R469) [[6]](diffhunk://#diff-5579fb43aff3bf7cfd1ba4e7c895b722d7a22eaf171bf0e88203a78aa48ef58eL447-R502)

**UI/UX improvements:**

* Improved button styling and wording for sign-in and sign-up actions in `components/HeaderContent.tsx`, changing "Sign Up" to "Get Started" and adding a "Sign in" button.
* Changed the "Available Projects" heading to use `font-semibold` instead of `font-bold` for consistency in `components/browse/ProjectCard.tsx`.

**Code maintenance:**

* Imported `ArchiveRestore` icon for use in unarchive actions in `components/project/ProjectDetail.tsx`.