### PR TITLE
Fix: allow user to unarchive project

### DIFF
--- a/components/HeaderContent.tsx
+++ b/components/HeaderContent.tsx
@@ -61,11 +61,19 @@ const HeaderContent: React.FC<HeaderContentProps> = ({
       <div className="text-gray-100 max-w-lg min-w-md">
         <SearchBar />
       </div>
-      <div>
+      <div className="flex items-center gap-2">
+        <Link href={"/sign-in"}>
+          <Button
+            variant={"ghost"}
+            className="text-white font-medium rounded-full hover:bg-[#695DCC]/40 hover:text-white"
+          >
+            Sign in
+          </Button>
+        </Link>
         <SignedOut>
           <Link href="/sign-up">
-            <Button className="cursor-pointer bg-[#695DCC] hover:bg-[#695DCC]/80 font-bold">
-              Sign Up
+            <Button className="cursor-pointer bg-[#695DCC] hover:bg-[#695DCC]/80 font-semibold rounded-full">
+              Get Started
             </Button>
           </Link>
         </SignedOut>

--- a/components/browse/ProjectCard.tsx
+++ b/components/browse/ProjectCard.tsx
@@ -99,7 +99,7 @@ export function ProjectCard({
   return (
     <div className="container mx-auto">
       <div className="w-full flex items-center justify-between px-6 mt-5">
-        <h1 className="font-bold text-lg">Available Projects</h1>
+        <h1 className="font-semibold text-lg">Available Projects</h1>
         <div className="flex items-center">
           <Button
             variant="outline"


### PR DESCRIPTION
This pull request introduces the ability for business owners to unarchive projects, allowing archived projects to be restored to an open status and made visible to applicants again. It also improves the user interface by updating button styles and labels for clarity and consistency.

**New project unarchiving functionality:**

* Added a new `unarchiveProject` function in `lib/actions/project.ts` to allow business owners to restore archived projects to the "OPEN" status, including authentication and role checks, and triggers page revalidation.
* Updated the `ProjectDetail` component to show an "Unarchive" button for archived projects, handle unarchive actions, and display appropriate confirmation dialogs and status messages. [[1]](diffhunk://#diff-5579fb43aff3bf7cfd1ba4e7c895b722d7a22eaf171bf0e88203a78aa48ef58eL132-R157) [[2]](diffhunk://#diff-5579fb43aff3bf7cfd1ba4e7c895b722d7a22eaf171bf0e88203a78aa48ef58eR216-R226) [[3]](diffhunk://#diff-5579fb43aff3bf7cfd1ba4e7c895b722d7a22eaf171bf0e88203a78aa48ef58eR236) [[4]](diffhunk://#diff-5579fb43aff3bf7cfd1ba4e7c895b722d7a22eaf171bf0e88203a78aa48ef58eL427-R469) [[5]](diffhunk://#diff-5579fb43aff3bf7cfd1ba4e7c895b722d7a22eaf171bf0e88203a78aa48ef58eL447-R502)

**UI and style improvements:**

* Improved button styling and labels in the header and project detail components, including changing "Sign Up" to "Get Started" and updating button variants and classes for better visual consistency. [[1]](diffhunk://#diff-6671ffc70c83206ad55e1edb2725c7a7bd9a8732dde3f3263cd81a403228b514L64-R76) [[2]](diffhunk://#diff-5579fb43aff3bf7cfd1ba4e7c895b722d7a22eaf171bf0e88203a78aa48ef58eR216-R226) [[3]](diffhunk://#diff-5579fb43aff3bf7cfd1ba4e7c895b722d7a22eaf171bf0e88203a78aa48ef58eR236)
* Updated the heading style for "Available Projects" in `ProjectCard.tsx` for consistency.

**Code maintenance:**

* Added the `ArchiveRestore` icon import and updated project action imports in `ProjectDetail.tsx` to support the new unarchive feature. [[1]](diffhunk://#diff-5579fb43aff3bf7cfd1ba4e7c895b722d7a22eaf171bf0e88203a78aa48ef58eL7-R7) [[2]](diffhunk://#diff-5579fb43aff3bf7cfd1ba4e7c895b722d7a22eaf171bf0e88203a78aa48ef58eL21-R25)