### PR TITLE
345 add character limits to skill field when creating or editing a project

### DIFF
--- a/components/project/EditProjectModal.tsx
+++ b/components/project/EditProjectModal.tsx
@@ -236,8 +236,18 @@ export function EditProjectModal({
   };
 
   const addSkill = (skill: string) => {
-    if (skill && !selectedSkills.includes(skill)) {
-      const newSkills = [...selectedSkills, skill];
+    const trimmedSkill = skill.trim();
+    if (trimmedSkill && !selectedSkills.includes(trimmedSkill)) {
+      // Enforce 20 character limit
+      if (trimmedSkill.length > 20) {
+        form.setError("requiredSkills", {
+          type: "manual",
+          message: "Each skill must be 20 characters or less",
+        });
+        return;
+      }
+      form.clearErrors("requiredSkills");
+      const newSkills = [...selectedSkills, trimmedSkill];
       setSelectedSkills(newSkills);
       form.setValue("requiredSkills", newSkills, {
         shouldDirty: true,
@@ -369,6 +379,7 @@ export function EditProjectModal({
                           onChange={(e) => setSkillInput(e.target.value)}
                           onKeyPress={handleKeyPress}
                           className="flex-1 text-sm"
+                          maxLength={20}
                         />
                         <Button
                           type="button"
@@ -423,7 +434,8 @@ export function EditProjectModal({
                   </FormControl>
                   <FormDescription className="text-xs">
                     Add skills required for this project. You can type custom
-                    skills or click the suggested ones.
+                    skills or click the suggested ones. Each skill is limited to
+                    20 characters.
                   </FormDescription>
                   <FormMessage />
                 </FormItem>

--- a/components/project/PostProjectModal.tsx
+++ b/components/project/PostProjectModal.tsx
@@ -216,8 +216,18 @@ export function PostProjectModal({
   };
 
   const addSkill = (skill: string) => {
-    if (skill && !selectedSkills.includes(skill)) {
-      const newSkills = [...selectedSkills, skill];
+    const trimmedSkill = skill.trim();
+    if (trimmedSkill && !selectedSkills.includes(trimmedSkill)) {
+      // Enforce 20 character limit
+      if (trimmedSkill.length > 20) {
+        form.setError("requiredSkills", {
+          type: "manual",
+          message: "Each skill must be 20 characters or less",
+        });
+        return;
+      }
+      form.clearErrors("requiredSkills");
+      const newSkills = [...selectedSkills, trimmedSkill];
       setSelectedSkills(newSkills);
       form.setValue("requiredSkills", newSkills, {
         shouldDirty: true,
@@ -352,6 +362,7 @@ export function PostProjectModal({
                           onChange={(e) => setSkillInput(e.target.value)}
                           onKeyPress={handleKeyPress}
                           className="flex-1 text-sm"
+                          maxLength={20}
                         />
                         <Button
                           type="button"
@@ -406,7 +417,8 @@ export function PostProjectModal({
                   </FormControl>
                   <FormDescription className="text-xs">
                     Add skills required for this project. You can type custom
-                    skills or click the suggested ones.
+                    skills or click the suggested ones. Each skill is limited to
+                    20 characters.
                   </FormDescription>
                   <FormMessage />
                 </FormItem>


### PR DESCRIPTION
This pull request adds validation and user guidance to ensure that each skill entered in the project modals is limited to 20 characters. The changes affect both the "Edit Project" and "Post Project" modals, improving user experience and data consistency.

Skill input validation and UI updates:

* Enforced a 20-character limit for each skill in the `addSkill` function of both `EditProjectModal` and `PostProjectModal`, including trimming whitespace and displaying an error message if the limit is exceeded. [[1]](diffhunk://#diff-52a65e3cf729bf7289cb9843f60e8442837c4045850d07dae3d0813b586832f3L239-R250) [[2]](diffhunk://#diff-29ce2c1651ec99d45ec4728fe44c3d90c21be501d58b7b011e725777e93eb10cL219-R230)
* Set the `maxLength` property to 20 on the skill input fields in both modals to prevent users from entering skills longer than allowed. [[1]](diffhunk://#diff-52a65e3cf729bf7289cb9843f60e8442837c4045850d07dae3d0813b586832f3R382) [[2]](diffhunk://#diff-29ce2c1651ec99d45ec4728fe44c3d90c21be501d58b7b011e725777e93eb10cR365)
* Updated the skill input description in both modals to inform users about the 20-character limit per skill. [[1]](diffhunk://#diff-52a65e3cf729bf7289cb9843f60e8442837c4045850d07dae3d0813b586832f3L426-R438) [[2]](diffhunk://#diff-29ce2c1651ec99d45ec4728fe44c3d90c21be501d58b7b011e725777e93eb10cL409-R421)