### PR TITLE
406 add more warning alert for unsaved changes

### DIFF
--- a/components/browse/ProjectCard.tsx
+++ b/components/browse/ProjectCard.tsx
@@ -268,9 +268,14 @@ export function ProjectCard({
                 </SheetTitle>
                 <div className="flex flex-col sm:flex-row items-start sm:items-center justify-between gap-3 sm:gap-0">
                   <div className="w-full sm:w-auto">
-                    <SheetDescription className="text-lg sm:text-xl lg:text-2xl font-bold text-gray-900 mt-2">
-                      {project.title}
-                    </SheetDescription>
+                    <Link
+                      href={`/project/${project.id}`}
+                      className="hover:underline"
+                    >
+                      <SheetDescription className="text-lg sm:text-xl lg:text-2xl font-bold text-gray-900 mt-2">
+                        {project.title}
+                      </SheetDescription>
+                    </Link>
                     <div className="flex flex-wrap items-center gap-1 sm:gap-0">
                       <SheetDescription className="font-medium text-xs sm:text-sm truncate">
                         {project.businessOwner.address}

--- a/components/project/ProjectDetail.tsx
+++ b/components/project/ProjectDetail.tsx
@@ -321,6 +321,12 @@ export function ProjectDetail({ project, timeline }: ProjectDetailProps) {
                 ))}
             </div>
           </div>
+          <div className="flex items-center gap-2 mt-2">
+            <Badge variant={"outline"}>
+              {project.category.replaceAll("_", " ")}
+            </Badge>
+            <Badge variant={"outline"}>{project.scope}</Badge>
+          </div>
         </div>
         <div className="grid flex-1 auto-rows-min gap-6 overflow-y-auto pt-10">
           <h2 className="font-semibold text-xl text-gray-900">


### PR DESCRIPTION
This pull request introduces several UI and UX improvements across the project browsing and chat components. The most significant changes enhance user experience in the chat interface by preventing accidental loss of unsent messages, improve accessibility and navigation for projects, and add visual cues for project categories and scope.

**Chat Experience Improvements:**

* Added an alert dialog in `IndividualChat` to warn users when closing a chat with an unsent message, preventing accidental message loss. The chat only closes after user confirmation. [[1]](diffhunk://#diff-fb1c0e87c2a75e0676cacf9c8dee751cbafab212b05c7383938987df00d96ce2R16-R25) [[2]](diffhunk://#diff-fb1c0e87c2a75e0676cacf9c8dee751cbafab212b05c7383938987df00d96ce2R73-R75) [[3]](diffhunk://#diff-fb1c0e87c2a75e0676cacf9c8dee751cbafab212b05c7383938987df00d96ce2R177-R189) [[4]](diffhunk://#diff-fb1c0e87c2a75e0676cacf9c8dee751cbafab212b05c7383938987df00d96ce2L211-R240) [[5]](diffhunk://#diff-fb1c0e87c2a75e0676cacf9c8dee751cbafab212b05c7383938987df00d96ce2R335-R353)
* Improved auto-scrolling behavior in `IndividualChat` so the chat only scrolls to bottom on initial load and not with every message, resulting in a smoother experience. [[1]](diffhunk://#diff-fb1c0e87c2a75e0676cacf9c8dee751cbafab212b05c7383938987df00d96ce2R91-R105) [[2]](diffhunk://#diff-fb1c0e87c2a75e0676cacf9c8dee751cbafab212b05c7383938987df00d96ce2L90-L98)
* Minor UI tweaks in `IndividualChat` to simplify class names and remove unnecessary wrappers, cleaning up the chat header. [[1]](diffhunk://#diff-fb1c0e87c2a75e0676cacf9c8dee751cbafab212b05c7383938987df00d96ce2L177-R208) [[2]](diffhunk://#diff-fb1c0e87c2a75e0676cacf9c8dee751cbafab212b05c7383938987df00d96ce2L187-L191)

**Project Navigation and Display:**

* Made project titles in `ProjectCard` clickable links, improving navigation to project details.
* Added badges for project category and scope in `ProjectDetail`, providing clearer at-a-glance information about each project.