### PR TITLE
429 allow users to delete their account

### DIFF
--- a/scripts/delete-user-script.ts
+++ b/scripts/delete-user-script.ts
@@ -1,0 +1,34 @@
+/**
+ * Test script to manually test user deletion
+ * Run with: npx ts-node --compiler-options '{"module":"commonjs"}' scripts/test-delete-user.ts <clerkId>
+ *
+ * Example: npx ts-node --compiler-options '{"module":"commonjs"}' scripts/test-delete-user.ts user_2abc123def
+ */
+
+import { deleteUser } from "../lib/actions/user";
+
+async function testDeleteUser() {
+  const clerkId = process.argv[2];
+
+  if (!clerkId) {
+    console.error("❌ Please provide a clerkId as an argument");
+    console.log(
+      'Usage: npx ts-node --compiler-options \'{"module":"commonjs"}\' scripts/test-delete-user.ts <clerkId>'
+    );
+    process.exit(1);
+  }
+
+  console.log(`\n🧪 Testing user deletion for clerkId: ${clerkId}\n`);
+
+  try {
+    const result = await deleteUser(clerkId);
+    console.log("\n✅ Deletion completed successfully!");
+    console.log("Result:", JSON.stringify(result, null, 2));
+  } catch (error) {
+    console.error("\n❌ Deletion failed!");
+    console.error("Error:", error);
+    process.exit(1);
+  }
+}
+
+testDeleteUser();


### PR DESCRIPTION
This pull request adds robust support for deleting users and all their associated data when a `user.deleted` event is received from Clerk webhooks. It introduces a comprehensive `deleteUser` function that ensures all related records (applications, projects, messages, conversations) are properly cleaned up or updated for data integrity. Additionally, a script is provided for manual testing of user deletion.

**Webhook integration and user deletion:**

* The Clerk webhook handler (`app/api/webhooks/clerk/route.ts`) now processes `user.deleted` events, invoking the new `deleteUser` function to remove the user and associated data. Improved logging and error handling are included for both user creation and deletion events. [[1]](diffhunk://#diff-b6cac72a643032ad0a97813620061df5e61908d4b2363ed339ca1aee0922583bL3-R3) [[2]](diffhunk://#diff-b6cac72a643032ad0a97813620061df5e61908d4b2363ed339ca1aee0922583bR51-R87)

**Database cleanup logic:**

* Added the `deleteUser` function in `lib/actions/user.ts`, which:
  - Deletes applications, messages, and disconnects the user from all conversations.
  - Cancels active projects posted by the user, archives completed projects, and resets assigned projects.
  - Removes the user from conversation participants and deletes empty conversations.
  - Deletes the user record itself, with detailed logging at each step.

**Testing and developer tooling:**

* Introduced a script (`scripts/delete-user-script.ts`) for manual testing of user deletion by Clerk ID, allowing developers to verify deletion logic outside of webhook events.