### PR TITLE
450 add some api routes to test

### DIFF
--- a/app/api/demo/users/[clerkId]/route.ts
+++ b/app/api/demo/users/[clerkId]/route.ts
@@ -1,0 +1,189 @@
+/**
+ * Demo API Routes for Individual User Operations
+ * These endpoints are created for demonstration purposes to show backend functionality
+ * The actual application uses Next.js Server Actions instead of REST APIs
+ */
+
+import { NextRequest, NextResponse } from "next/server";
+import prisma from "@/lib/prisma";
+
+interface RouteParams {
+  params: Promise<{ clerkId: string }>;
+}
+
+/**
+ * GET /api/demo/users/[clerkId]
+ * Fetch a specific user by their Clerk ID
+ *
+ * Example: GET /api/demo/users/user_2abc123xyz
+ */
+export async function GET(request: NextRequest, { params }: RouteParams) {
+  try {
+    const { clerkId } = await params;
+
+    if (!clerkId) {
+      return NextResponse.json(
+        {
+          success: false,
+          error: "clerkId parameter is required",
+        },
+        { status: 400 }
+      );
+    }
+
+    const user = await prisma.user.findFirst({
+      where: { clerkId },
+      select: {
+        id: true,
+        clerkId: true,
+        email: true,
+        firstName: true,
+        lastName: true,
+        bio: true,
+        intro: true,
+        address: true,
+        skills: true,
+        imageUrl: true,
+        role: true,
+        occupied: true,
+        createdAt: true,
+        updatedAt: true,
+        totalHoursContributed: true,
+        projectsCompleted: true,
+        industriesExperienced: true,
+        education: true,
+        experiences: true,
+        socialLinks: true,
+        previousProjects: true,
+        earnedSkillBadges: true,
+        earnedSpecializationBadges: true,
+        earnedEngagementBadges: true,
+      },
+    });
+
+    if (!user) {
+      return NextResponse.json(
+        {
+          success: false,
+          error: "User not found",
+        },
+        { status: 404 }
+      );
+    }
+
+    return NextResponse.json({
+      success: true,
+      data: user,
+    });
+  } catch (error) {
+    console.error("Error fetching user:", error);
+    return NextResponse.json(
+      {
+        success: false,
+        error: "Failed to fetch user",
+        details: error instanceof Error ? error.message : "Unknown error",
+      },
+      { status: 500 }
+    );
+  }
+}
+
+/**
+ * PATCH /api/demo/users/[clerkId]
+ * Update a user's profile (bio, intro, firstName, lastName, etc.)
+ *
+ * Request Body (all fields optional):
+ * {
+ *   "firstName": "string",
+ *   "lastName": "string",
+ *   "bio": "string",
+ *   "intro": "string",
+ *   "address": "string",
+ *   "skills": ["string", "string"]
+ * }
+ *
+ * Example: PATCH /api/demo/users/user_2abc123xyz
+ */
+export async function PATCH(request: NextRequest, { params }: RouteParams) {
+  try {
+    const { clerkId } = await params;
+
+    if (!clerkId) {
+      return NextResponse.json(
+        {
+          success: false,
+          error: "clerkId parameter is required",
+        },
+        { status: 400 }
+      );
+    }
+
+    const body = await request.json();
+
+    // Only allow specific fields to be updated
+    const allowedFields = [
+      "firstName",
+      "lastName",
+      "bio",
+      "intro",
+      "address",
+      "skills",
+    ];
+    const updateData: Record<string, unknown> = {};
+
+    for (const field of allowedFields) {
+      if (body[field] !== undefined) {
+        updateData[field] = body[field];
+      }
+    }
+
+    if (Object.keys(updateData).length === 0) {
+      return NextResponse.json(
+        {
+          success: false,
+          error:
+            "No valid fields to update. Allowed fields: " +
+            allowedFields.join(", "),
+        },
+        { status: 400 }
+      );
+    }
+
+    // Check if user exists
+    const existingUser = await prisma.user.findFirst({
+      where: { clerkId },
+    });
+
+    if (!existingUser) {
+      return NextResponse.json(
+        {
+          success: false,
+          error: "User not found",
+        },
+        { status: 404 }
+      );
+    }
+
+    const updatedUser = await prisma.user.update({
+      where: { clerkId },
+      data: updateData,
+    });
+
+    return NextResponse.json({
+      success: true,
+      message: "User profile updated successfully",
+      data: updatedUser,
+      updatedFields: Object.keys(updateData),
+    });
+  } catch (error) {
+    console.error("Error updating user:", error);
+    return NextResponse.json(
+      {
+        success: false,
+        error: "Failed to update user",
+        details: error instanceof Error ? error.message : "Unknown error",
+      },
+      { status: 500 }
+    );
+  }
+}

--- a/app/api/demo/users/route.ts
+++ b/app/api/demo/users/route.ts
@@ -1,0 +1,166 @@
+/**
+ * Demo API Routes for User/Profile Operations
+ * These endpoints are created for demonstration purposes to show backend functionality
+ * The actual application uses Next.js Server Actions instead of REST APIs
+ */
+
+import { NextRequest, NextResponse } from "next/server";
+import prisma from "@/lib/prisma";
+
+/**
+ * GET /api/demo/users
+ * Fetch all users from the database
+ *
+ * Query Parameters:
+ * - limit: number (optional) - Limit the number of results
+ * - offset: number (optional) - Skip a number of results for pagination
+ *
+ * Example: GET /api/demo/users?limit=10&offset=0
+ */
+export async function GET(request: NextRequest) {
+  try {
+    const { searchParams } = new URL(request.url);
+    const limit = parseInt(searchParams.get("limit") || "10");
+    const offset = parseInt(searchParams.get("offset") || "0");
+
+    const users = await prisma.user.findMany({
+      take: limit,
+      skip: offset,
+      select: {
+        id: true,
+        clerkId: true,
+        email: true,
+        firstName: true,
+        lastName: true,
+        bio: true,
+        intro: true,
+        address: true,
+        skills: true,
+        imageUrl: true,
+        role: true,
+        occupied: true,
+        createdAt: true,
+        updatedAt: true,
+        totalHoursContributed: true,
+        projectsCompleted: true,
+        industriesExperienced: true,
+        education: true,
+        experiences: true,
+        socialLinks: true,
+      },
+    });
+
+    const totalCount = await prisma.user.count();
+
+    return NextResponse.json({
+      success: true,
+      data: users,
+      pagination: {
+        total: totalCount,
+        limit,
+        offset,
+        hasMore: offset + users.length < totalCount,
+      },
+    });
+  } catch (error) {
+    console.error("Error fetching users:", error);
+    return NextResponse.json(
+      {
+        success: false,
+        error: "Failed to fetch users",
+        details: error instanceof Error ? error.message : "Unknown error",
+      },
+      { status: 500 }
+    );
+  }
+}
+
+/**
+ * POST /api/demo/users
+ * Create a new user (Demo only - actual user creation happens via Clerk webhook)
+ *
+ * Request Body:
+ * {
+ *   "clerkId": "string",
+ *   "email": "string",
+ *   "firstName": "string" (optional),
+ *   "lastName": "string" (optional),
+ *   "bio": "string" (optional),
+ *   "intro": "string" (optional)
+ * }
+ */
+export async function POST(request: NextRequest) {
+  try {
+    const body = await request.json();
+
+    const { clerkId, email, firstName, lastName, bio, intro } = body;
+
+    if (!clerkId || !email) {
+      return NextResponse.json(
+        {
+          success: false,
+          error: "Missing required fields: clerkId and email are required",
+        },
+        { status: 400 }
+      );
+    }
+
+    // Check if user already exists
+    const existingUser = await prisma.user.findFirst({
+      where: {
+        OR: [{ clerkId }, { email }],
+      },
+    });
+
+    if (existingUser) {
+      return NextResponse.json(
+        {
+          success: false,
+          error: "User with this clerkId or email already exists",
+        },
+        { status: 409 }
+      );
+    }
+
+    const newUser = await prisma.user.create({
+      data: {
+        clerkId,
+        email,
+        firstName: firstName || null,
+        lastName: lastName || null,
+        bio: bio || null,
+        intro: intro || null,
+        role: "USER",
+        occupied: false,
+        totalHoursContributed: 0,
+        projectsCompleted: 0,
+        industriesExperienced: [],
+        socialLinks: [],
+        experiences: [],
+        education: [],
+        earnedSkillBadges: [],
+        earnedSpecializationBadges: [],
+        earnedEngagementBadges: [],
+      },
+    });
+
+    return NextResponse.json(
+      {
+        success: true,
+        message: "User created successfully",
+        data: newUser,
+      },
+      { status: 201 }
+    );
+  } catch (error) {
+    console.error("Error creating user:", error);
+    return NextResponse.json(
+      {
+        success: false,
+        error: "Failed to create user",
+        details: error instanceof Error ? error.message : "Unknown error",
+      },
+      { status: 500 }
+    );
+  }
+}

--- a/middleware.ts
+++ b/middleware.ts
@@ -5,6 +5,7 @@ const isPublicRoute = createRouteMatcher([
   "/sign-up(.*)",
   "/",
   "/api/webhooks(.*)",
+  "/api/demo(.*)", // Demo API routes for Postman testing
   "/profile(.*)",
   "/docs(.*)",
 ]);

--- a/next.config.mjs
+++ b/next.config.mjs
@@ -3,19 +3,16 @@ import { createMDX } from "fumadocs-mdx/next";
 /** @type {import('next').NextConfig} */
 const config = {
   reactStrictMode: true,
-  
+
   // Performance optimizations
   images: {
-    formats: ['image/avif', 'image/webp'],
+    formats: ["image/avif", "image/webp"],
     deviceSizes: [640, 750, 828, 1080, 1200, 1920, 2048, 3840],
     imageSizes: [16, 32, 48, 64, 96, 128, 256, 384],
   },
-  
+
   // Compress output
   compress: true,
-  
-  // Enable SWC minification (faster than Terser)
-  swcMinify: true,
 };
 
 const withMDX = createMDX({


### PR DESCRIPTION
This pull request introduces a set of demo REST API endpoints for user operations to facilitate backend testing and demonstration, while clarifying that the production app uses Next.js Server Actions. It also updates public route matching to allow unauthenticated access to these demo APIs and makes a minor formatting change in the Next.js image configuration.

**Demo API Endpoints for User Operations**

* Added `app/api/demo/users/route.ts` with GET (fetch all users, supports pagination) and POST (create user for demo purposes) endpoints, including error handling and validation.
* Added `app/api/demo/users/[clerkId]/route.ts` with GET (fetch user by Clerk ID) and PATCH (update user profile fields) endpoints, including field whitelisting and robust error handling. ([app/api/demo/users/[clerkId]/route.tsR1-R189](diffhunk://#diff-9d411494d49bcaf3670de13c9b68204a0376950ecca9a4042df9edff11826910R1-R189))

**Middleware and Configuration Updates**

* Added `/api/demo(.*)` to the public route matcher in `middleware.ts` so demo API endpoints are accessible without authentication, which is useful for Postman or similar tools.
* Minor formatting update in the `images.formats` array in `next.config.mjs` for consistency (no functional impact).